### PR TITLE
LGFX_Spriteの確保の仕方を変更 (　LovyanGFX 0.4.0以降での動作を確認済 )

### DIFF
--- a/src/M5ImageAvatarLite.cpp
+++ b/src/M5ImageAvatarLite.cpp
@@ -28,15 +28,6 @@ void ImageAvatarLite::init(LGFX *gfx, const char* filename, bool is_change,
     loadConfig(*_json_fs, filename);
     this->_gfx = gfx;
     this->_filename = filename;
-    _lcd_sp      = new LGFX_Sprite(_gfx);
-    _head_sp     = new LGFX_Sprite(&_lcd_sp);
-    _mouth_sp    = new LGFX_Sprite(&_lcd_sp);
-    _mouth_op_sp = new LGFX_Sprite(&_lcd_sp);
-    _mouth_cl_sp = new LGFX_Sprite(&_lcd_sp);
-    _eye_l_sp    = new LGFX_Sprite(&_lcd_sp);
-    _eye_r_sp    = new LGFX_Sprite(&_lcd_sp);
-    _eye_op_sp   = new LGFX_Sprite(&_lcd_sp);
-    _eye_cl_sp   = new LGFX_Sprite(&_lcd_sp);
     _expression = expression;
     _mv = _config.getMoveParameters(_expression);
     initSprites(is_change);

--- a/src/M5ImageAvatarLite.h
+++ b/src/M5ImageAvatarLite.h
@@ -10,15 +10,15 @@ class ImageAvatarLite
 {
     private:
         LGFX *_gfx;
-        LGFX_Sprite _head_sp;     // 頭（背景）用スプライト
-        LGFX_Sprite _eye_op_sp;   // 開いた右目のスプライト
-        LGFX_Sprite _eye_cl_sp;   // 閉じた右目のスプライト
-        LGFX_Sprite _mouth_op_sp; // 開いた口のスプライト
-        LGFX_Sprite _mouth_cl_sp; // 閉じた口のスプライト
-        LGFX_Sprite _mouth_sp;    // 口描画用スプライト
-        LGFX_Sprite _eye_l_sp;    // 左目描画用スプライト
-        LGFX_Sprite _eye_r_sp;    // 右目描画用スプライト
         LGFX_Sprite _lcd_sp;      // LCDに最終的に描画する直前のスプライト
+        LGFX_Sprite _head_sp = { &_lcd_sp };     // 頭（背景）用スプライト
+        LGFX_Sprite _eye_op_sp = { &_lcd_sp };   // 開いた右目のスプライト
+        LGFX_Sprite _eye_cl_sp = { &_lcd_sp };   // 閉じた右目のスプライト
+        LGFX_Sprite _mouth_op_sp = { &_lcd_sp }; // 開いた口のスプライト
+        LGFX_Sprite _mouth_cl_sp = { &_lcd_sp }; // 閉じた口のスプライト
+        LGFX_Sprite _mouth_sp = { &_lcd_sp };    // 口描画用スプライト
+        LGFX_Sprite _eye_l_sp = { &_lcd_sp };    // 左目描画用スプライト
+        LGFX_Sprite _eye_r_sp = { &_lcd_sp };    // 右目描画用スプライト
         move_param_s _mv;
 
         bool _is_change;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@
   bool servo_enable = false; // サーボを動かすかどうか
   TaskHandle_t moveservoTaskHangle;
 #endif
-static LGFX gfx;
+LGFX &gfx ( M5.Lcd );
 
 // JSONファイルとBMPファイルを置く場所を切り替え
 // 開発時はSPIFFS上に置いてUploadするとSDカードを抜き差しする手間が省けます。


### PR DESCRIPTION
各パーツの LGFX_Sprite は宣言時点で静的確保できているので、 new で代入しないように変更しました。
_lcd_sp の描画先は実行時に pushSpriteで指定しているため、宣言時には省略しても大丈夫です。

 LovyanGFX0.4.5で動作を確認しています。